### PR TITLE
tests: Change LDI rather than `self` properties

### DIFF
--- a/linz-data-importer/tests/test_ldi_integration.py
+++ b/linz-data-importer/tests/test_ldi_integration.py
@@ -147,7 +147,7 @@ class CorruptXml(unittest.TestCase):
         QTest.qWait(WAIT)
         self.ldi.dlg.uTextFilter.setText("")
         self.ldi.dlg.close()
-        self.services_loaded = False
+        self.ldi.services_loaded = False
 
     def test_handle_corrupt_xml(self):
         """
@@ -290,7 +290,7 @@ class UserWorkFlows(unittest.TestCase):
         self.ldi.dlg.uTextFilter.setText("")
         self.ldi.dlg.close()
         QgsProject.instance().removeAllMapLayers()
-        self.services_loaded = False
+        self.ldi.services_loaded = False
         item = self.ldi.dlg.uListOptions.findItems("ALL", Qt.MatchFixedString)[0]
         self.ldi.dlg.uListOptions.itemClicked.emit(item)
 

--- a/linz-data-importer/tests/test_ldi_plugin.py
+++ b/linz-data-importer/tests/test_ldi_plugin.py
@@ -368,8 +368,8 @@ class UnitLevel(unittest.TestCase):
             file_path = os.path.join(self.pl_settings_dir, file)
             insitu_file_stats[file] = os.stat(file_path).st_mtime
 
-        self.cache_updated = False
-        self.update_cache = True
+        self.ldi.cache_updated = False
+        self.ldi.update_cache = True
         self.ldi.updateServiceDataCache()
         QTest.qWait(15000)
 

--- a/linz-data-importer/tests/test_ldi_ui_elements.py
+++ b/linz-data-importer/tests/test_ldi_ui_elements.py
@@ -54,7 +54,7 @@ class UiTest(unittest.TestCase):
 
         QTest.qWait(WAIT)  # Just because I want to watch it open a close
         self.ldi.dlg.close()
-        self.services_loaded = False
+        self.ldi.services_loaded = False
 
         # Remove filter set tab back to "ALL"
         item = self.ldi.dlg.uListOptions.findItems("ALL", Qt.MatchFixedString)[0]


### PR DESCRIPTION
Not sure how this affects the test run, but setting these on `self`
presumably had no effect.

Closes https://github.com/linz/linz-data-importer/issues/129.