### PR TITLE
fix(basemaps): fix Basemaps TMS and CRS handling

### DIFF
--- a/linz-data-importer/service_data.py
+++ b/linz-data-importer/service_data.py
@@ -442,7 +442,7 @@ class ServiceData(Localstore):  # pylint: disable=too-many-instance-attributes
             if self.service == "wmts":
                 tms = self.obj.tilematrixsets
                 ogc_crs = [tms[t].crs for t in tms]
-                self.crs = ["EPSG:{0}".format(item.split(':')[-1]) for item in ogc_crs]
+                self.crs = ["EPSG:{0}".format(item.split(":")[-1]) for item in ogc_crs]
                 self.sort_crs()
             elif self.service == "wfs":
                 self.crs = dataset_obj.crsOptions

--- a/linz-data-importer/service_data.py
+++ b/linz-data-importer/service_data.py
@@ -440,7 +440,9 @@ class ServiceData(Localstore):  # pylint: disable=too-many-instance-attributes
                 object_id = full_id.group("id")
             # Get and standarise espg codes
             if self.service == "wmts":
-                self.crs = dataset_obj.tilematrixsets
+                tms = self.obj.tilematrixsets
+                ogc_crs = [tms[t].crs for t in tms]
+                self.crs = ["EPSG:{0}".format(item.split(':')[-1]) for item in ogc_crs]
                 self.sort_crs()
             elif self.service == "wfs":
                 self.crs = dataset_obj.crsOptions


### PR DESCRIPTION
Fixes #159 

This plugin was extracting the CRS from the TileMatrixSet name rather than from the SupportedCRS element within the TileMatrixSet. This PR changes that behaviour to fix the Basemaps integration.